### PR TITLE
UI fixes #923

### DIFF
--- a/index.html
+++ b/index.html
@@ -2501,7 +2501,7 @@
       <tbody>
         <tr>
           <td>
-            <span class="add-on layout-text">Layout Style</span>
+            <span class="add-on layout-text">Style</span>
           </td>
 
           <td>
@@ -2522,7 +2522,7 @@
       <span class="add-on layout-text" title="Node repulsion (non overlapping) multiplier"> Node Repulsion </span>
       </td>
       <td>
-      <input id="node-repulsion" type="text" min="0" class="sbgn-input-small layout-text integer-input" value= <%= nodeRepulsion %> >
+      <input id="node-repulsion" type="number" min="0" class="sbgn-input-small layout-text integer-input" value= <%= nodeRepulsion %> >
       </td>
       </tr>
 
@@ -2531,7 +2531,7 @@
       <span class="add-on layout-text" title="Ideal (intra-graph) edge length"> Ideal Edge Length </span>
       </td>
       <td>
-      <input id="ideal-edge-length" type="text" min="5" class="sbgn-input-small layout-text integer-input" value= <%= idealEdgeLength %> >
+      <input id="ideal-edge-length" type="number" min="5" class="sbgn-input-small layout-text integer-input" value= <%= idealEdgeLength %> >
       </td>
       </tr>
 
@@ -2594,7 +2594,7 @@
       <span class="add-on layout-text" title="Maximum number of iterations to perform"> Number of Iterations </span>
       </td>
       <td>
-      <input id="num-iter" type="text" min="0" class="sbgn-input-small layout-text integer-input" value= <%= numIter %> >
+      <input id="num-iter" type="number" min="0" class="sbgn-input-small layout-text integer-input" value= <%= numIter %> >
       </td>
       </tr>
 
@@ -2603,7 +2603,7 @@
       <span class="add-on layout-text" title="Amount of vertical space to put between degree zero nodes during tiling"> Tiling Vertical Padding </span>
       </td>
       <td>
-      <input id="tiling-padding-vertical" type="text" min="0" class="sbgn-input-small layout-text integer-input" value= <%= tilingPaddingVertical %> >
+      <input id="tiling-padding-vertical" type="number" min="0" class="sbgn-input-small layout-text integer-input" value= <%= tilingPaddingVertical %> >
       </td>
       </tr>
 
@@ -2612,7 +2612,7 @@
       <span class="add-on layout-text" title="Amount of horizontal space to put between degree zero nodes during tiling"> Tiling Horizontal Padding </span>
       </td>
       <td>
-      <input id="tiling-padding-horizontal" type="text" min="0" class="sbgn-input-small layout-text integer-input" value= <%= tilingPaddingHorizontal %> >
+      <input id="tiling-padding-horizontal" type="number" min="0" class="sbgn-input-small layout-text integer-input" value= <%= tilingPaddingHorizontal %> >
       </td>
       </tr>
 


### PR DESCRIPTION
The redundant “Layout” text was removed. Some input types were changed from `text` to `number` because they were incorrectly classified and caused a slight extra margin on the left